### PR TITLE
Item template update - should fix #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ _vti_pvt/
 
 #Ignore private folder
 /Private/
+/Source/UpgradeLog.htm

--- a/Source/ExtensionClass/ExtensionClass.vstemplate
+++ b/Source/ExtensionClass/ExtensionClass.vstemplate
@@ -6,6 +6,7 @@
     <Icon>ExtensionClass.ico</Icon>
     <TemplateID>f8451166-5b1e-4d52-8765-159447f3ef5f</TemplateID>
     <ProjectType>CSharp</ProjectType>
+    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>Class.cs</DefaultName>

--- a/Source/UtilityClass/UtilityClass.vstemplate
+++ b/Source/UtilityClass/UtilityClass.vstemplate
@@ -6,6 +6,7 @@
     <Icon>UtilityClass.ico</Icon>
     <TemplateID>d940ba84-d398-48da-88b3-2cd0ecc82b18</TemplateID>
     <ProjectType>CSharp</ProjectType>
+    <AppliesTo>CSharp + SharedAssetsProject</AppliesTo>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <DefaultName>Class.cs</DefaultName>


### PR DESCRIPTION
Seems that this minor addition to the item templates should fix this issue. With it, I managed to successfully display and add an item template in a Shared Project; the behavior seemed identical to what we experience in normal projects.

Although what I updated for the testing is actually the "vstman" manifest file that Visual Studio creates from the "vstemplate" files (and uses instead, if my understanding is correct). But installing an updated VSIX should refresh these manifests automatically, I suppose. Admittedly, I hardly know anything about using templates in extensions.

At any rate, test the solution, and reject if it doesn't work. :)