### PR TITLE
Updated to support VS 2019

### DIFF
--- a/Source/MDK/source.extension.vsixmanifest
+++ b/Source/MDK/source.extension.vsixmanifest
@@ -12,7 +12,7 @@ Space Engineers is trademarked to Keen Software House. This toolkit is fan-made,
     <Tags>SpaceEngineers Space Engineers Programmable Block PB Ingame Script</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
@@ -29,7 +29,7 @@ Space Engineers is trademarked to Keen Software House. This toolkit is fan-made,
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="MDKAnalyzer" d:VsixSubPath="Analyzers" Path="|MDKAnalyzer|" AssemblyName="|MDKAnalyzer;AssemblyName|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,16.0)" DisplayName="Roslyn Language Services" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="Roslyn Language Services" />
   </Prerequisites>
 </PackageManifest>

--- a/Source/MDKAnalyzer/MDKAnalyzer.Vsix/source.extension.vsixmanifest
+++ b/Source/MDKAnalyzer/MDKAnalyzer.Vsix/source.extension.vsixmanifest
@@ -16,7 +16,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="MDKAnalyzer" Path="|MDKAnalyzer|"/>
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,16.0)" DisplayName="Roslyn Language Services" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="Roslyn Language Services" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Pretty much just followed this [guide](https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/). I wasn't able to test it because VS wouldn't let me hear the end of the compatibility warnings between framework 4.6.1 and 4.7.2, so I'd recommend testing before accepting.

Hope we can get this (or something) in soon, since I've uninstalled VS 2017.