### PR TITLE
Fix-67: Fix version requirements to 15.6.7

### DIFF
--- a/Source/MDK/source.extension.vsixmanifest
+++ b/Source/MDK/source.extension.vsixmanifest
@@ -12,7 +12,7 @@ Space Engineers is trademarked to Keen Software House. This toolkit is fan-made,
     <Tags>SpaceEngineers Space Engineers Programmable Block PB Ingame Script</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27428.2043,16.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />


### PR DESCRIPTION
Validated this worked with VS 15.6.7 as a blocker. 

[15.0.27428.2043,16.0) -> Allows 15.6.7 to install plugin
(15.0.27428.2043,16.0)-> Does not allow 15.6.7 to install plugin. 

https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2017
The trick is that the version list for Visual Studio calls out the version as 15.6.27428.2043 but that just blocks all versions of 2017 (I've got 15.9.11 and 15.6.7 installed). If you use 15.0.27428.2043 instead, it works. And by validating with the [ vs ( syntax, I've been able to prove it at least is the correct string for 15.6.7 specifically.

With that, I've also validated that 15.0.27428 blocks as well on 15.6.7. Since I can't get 15.6.0 specifically I can't 100% test it, but I think that is the correct string to block on it.

I submitted this with the specific 15.6.7 version, but can change it to the 15.6 one and resubmit. 

I'm not sure if you have the older versions to test with or not, I was using https://docs.microsoft.com/en-us/visualstudio/productinfo/installing-an-earlier-release-of-vs2017 as the link (and wayback for 15.4.5)

(Sorry about the force-push, I was using it as an example for a friend of some git-fu)

