### PR TITLE
VS2019 Dev support: Remove unused refs and add Microsoft.MSBuild package

### DIFF
--- a/Source/ExtensionClass/ExtensionClass.csproj
+++ b/Source/ExtensionClass/ExtensionClass.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/IngameScriptTemplate/IngameScriptTemplate.csproj
+++ b/Source/IngameScriptTemplate/IngameScriptTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/MDK/MDK.csproj
+++ b/Source/MDK/MDK.csproj
@@ -296,6 +296,12 @@
     <Reference Include="JetBrains.Annotations, Version=2018.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.2018.2.1\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.15.1.1012\lib\net46\Microsoft.Build.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.Framework.15.1.1012\lib\net46\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.9.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>

--- a/Source/MDK/app.config
+++ b/Source/MDK/app.config
@@ -114,6 +114,10 @@
         <assemblyIdentity name="SQLitePCLRaw.batteries_v2" publicKeyToken="8226ea5df37bcae9" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.11.121" newVersion="1.1.11.121" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/Source/MDK/packages.config
+++ b/Source/MDK/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net461" />
   <package id="ManagedEsent" version="1.9.4" targetFramework="net461" />
+  <package id="Microsoft.Build" version="15.1.1012" targetFramework="net461" />
+  <package id="Microsoft.Build.Framework" version="15.1.1012" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.9.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.9.0" targetFramework="net461" />

--- a/Source/MixinProjectTemplate/MixinProjectTemplate.csproj
+++ b/Source/MixinProjectTemplate/MixinProjectTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/ReadMe/ReadMe.csproj
+++ b/Source/ReadMe/ReadMe.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReadMe</RootNamespace>
     <AssemblyName>ReadMe</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
@@ -45,9 +46,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/Source/UtilityClass/UtilityClass.csproj
+++ b/Source/UtilityClass/UtilityClass.csproj
@@ -46,9 +46,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
The CoreUtility assembly doesn't appear to end up in the end project so I removed them;

Added Microsoft.MSBuild 15.1.x as a nuget package so it can build correctly between VS2017/2019

Updated ReadMe project to use 4.6.1 instead of 4.6.2