### PR TITLE
Bugfix/172 Fixes generic types and non-generic types being collated

### DIFF
--- a/Source/MDK/Build/AnalysisExtensions.cs
+++ b/Source/MDK/Build/AnalysisExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -160,7 +160,7 @@ namespace MDK.Build
         {
             var ident = new List<string>(10)
             {
-                typeDeclaration.Identifier.ToString()
+                $"{typeDeclaration.Identifier}{typeDeclaration.TypeParameterList}"
             };
             var parent = typeDeclaration.Parent;
             while (parent != null)

--- a/Source/MDK/Build/AnalysisExtensions.cs
+++ b/Source/MDK/Build/AnalysisExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -53,6 +53,17 @@ namespace MDK.Build
         /// <returns></returns>
         public static string GetFullName(this ISymbol symbol, DeclarationFullNameFlags flags = DeclarationFullNameFlags.Default)
         {
+            if (symbol is INamedTypeSymbol namedType)
+            {
+              var declaratorSyntax = namedType
+                .DeclaringSyntaxReferences
+                .First()
+                .GetSyntax();
+              if (declaratorSyntax is TypeDeclarationSyntax typeDeclaration)
+              {
+                 return typeDeclaration.GetFullName(flags);
+              }
+            }
             var ident = new List<string>(10)
             {
                 symbol.Name


### PR DESCRIPTION
Apologies in advance if I've missed a process or anything since this is my first PR.

This PR edits the 'naming' of types to determine if they're being referenced or not, and thus if they can be trimmed.
If a symbol is a reference of a type, then we defer the naming of that symbol to the type itself. (note that First() is used since in the case of partial classes, there might be multiple locations it's defined, but any one of them should all work for the purpose of the class's name)
This PR also makes an edit to the naming of types, including the `<T>` generic parameters if the type has any.

Thus, a reference should generate the same name as the type declaration, and the type declaration should respect generics.

Should fix #172 

Let me know if you want me to add some test cases or anything, though I don't actually program in C# so I might need some handholding for more advanced things.