### PR TITLE
Fixed WhitelistExtractor crash

### DIFF
--- a/Source/MDKWhitelistExtractor/ExtractorPlugin.cs
+++ b/Source/MDKWhitelistExtractor/ExtractorPlugin.cs
@@ -160,7 +160,7 @@ namespace Malware.MDKWhitelistExtractor
             visitedAssemblies = visitedAssemblies ?? new HashSet<AssemblyName>(new AssemblyNameComparer());
             visitedAssemblies.Add(gameAssembly.GetName());
             var companyAttribute = gameAssembly.GetCustomAttribute<AssemblyCompanyAttribute>();
-            if (companyAttribute?.Company == "Microsoft Corporation")
+            if (companyAttribute?.Company == "Microsoft Corporation" || companyAttribute?.Company == "ProtoBuf.Net.Core")
                 yield break;
 
             var types = gameAssembly.DefinedTypes.Where(type => type.HasAttribute<MyCubeBlockTypeAttribute>());


### PR DESCRIPTION
ProtoBuf.Net.Core is now skipped by the FIndBlocks method.

ProtoBuf.Net.Core was problematic in that it referenced version 4.5.0.3 of System.ServiceModels.Primitives, which it cannot find.

An alternative way to fix this would be to handle this exception without rethrowing it. I'm not familiar enough with the past development of this project to know which is the better approach.